### PR TITLE
Specify jdk8 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: android
 
+jdk:
+    - oraclejdk8
+
 android:
     components:
         - platform-tools


### PR DESCRIPTION
Hi,

This PR sets up JDK8 for Travis build. This should fix the build.
